### PR TITLE
reduce console logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
       "integrity": "sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==",
       "dev": true
     },
+    "@types/debug": {
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.31.tgz",
+      "integrity": "sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==",
+      "dev": true
+    },
     "@types/dotenv": {
       "version": "4.0.3",
       "resolved": "http://registry.npmjs.org/@types/dotenv/-/dotenv-4.0.3.tgz",
@@ -461,12 +467,11 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -1147,6 +1152,15 @@
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -1161,6 +1175,12 @@
             "path-is-absolute": "^1.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -1173,10 +1193,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "murmurhash": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.6",
+    "@types/debug": "0.0.31",
     "@types/dotenv": "^4.0.3",
     "@types/js-yaml": "^3.11.2",
     "@types/mocha": "^5.2.5",
@@ -41,6 +42,7 @@
   },
   "dependencies": {
     "ajv": "^6.5.4",
+    "debug": "^4.1.0",
     "js-yaml": "^3.12.0",
     "murmurhash": "0.0.2",
     "number-to-words": "^1.2.4",

--- a/src/ingestors/category_builder.ts
+++ b/src/ingestors/category_builder.ts
@@ -1,3 +1,6 @@
+import * as Debug from 'debug';
+const debug = Debug('tf:category');
+
 import { generateAliases, Item, PID, StemmerFunction } from '..';
 
 export type PIDAllocator = () => PID;
@@ -69,7 +72,7 @@ export function categoryBuilder<ITEM extends Item>(
             const sortedPIDs = pids.sort((n1,n2) => n1 - n2);
             const categoryPID = pidAllocator();
             const name = `MULTIPLE_${sortedPIDs.join("_")}`;
-            console.log(`New category ${name},${categoryPID}: "${alias}": ${sortedPIDs}`);
+            debug(`New category ${name},${categoryPID}: "${alias}": ${sortedPIDs}`);
             items2.set(
                 categoryPID,
                 {pid: categoryPID, name, aliases: [alias]});

--- a/src/tokenizer/pattern_recognizer.ts
+++ b/src/tokenizer/pattern_recognizer.ts
@@ -11,6 +11,9 @@ import {
     WordToken
 } from '.';
 
+import * as Debug from 'debug';
+const debug = Debug('tf:pipeline');
+
 export class PatternRecognizer<ITEM extends Item> implements Recognizer {
     items: Map<PID, ITEM>;
     tokenizer: Tokenizer;
@@ -45,7 +48,7 @@ export class PatternRecognizer<ITEM extends Item> implements Recognizer {
         }
 
         // TODO: print name of tokenizer here?
-        console.log(`${this.items.size} items contributed ${aliasCount} aliases.`);
+        debug(`${this.items.size} items contributed ${aliasCount} aliases.`);
     }
 
     apply = (tokens: Token[]) => {


### PR DESCRIPTION
this impacts running tests from a consumer of this
library - its too verbose

the debug library is a well known and used library
that if you set an ENV variable to DEBUG=tf:* the logs will come back
and see the Debug package readme for more information


FYI: this was tested by cloning local this repo on the fix branch.  then using `npm link`. And wow, so much nicer :)
step 1 from THIS repo 
```
npm link
```

then in the dependant consumer project
```
npm link token-flow
```

![image](https://user-images.githubusercontent.com/1080406/49669579-c3c9f680-fa2f-11e8-9d71-6b134ef37c9d.png)
